### PR TITLE
이메일로 회원식별키를 받아오는 기능 추가

### DIFF
--- a/src/main/java/com/nhnacademy/book/member/domain/controller/MemberController.java
+++ b/src/main/java/com/nhnacademy/book/member/domain/controller/MemberController.java
@@ -102,4 +102,9 @@ public class MemberController {
         memberService.updateMemberByAdmin(memberModifyByAdminRequestDto.getOriginalEmail(), memberModifyByAdminRequestDto);
         return ResponseEntity.ok().build();
     }
+
+    // 이메일로 회원식별키 조회
+    public ResponseEntity<Long> getMemberIdByEmail(@RequestHeader("X-USER-ID") String email) {
+        return ResponseEntity.ok(memberService.getMemberIdByEmail(email));
+    }
 }

--- a/src/main/java/com/nhnacademy/book/member/domain/controller/MemberController.java
+++ b/src/main/java/com/nhnacademy/book/member/domain/controller/MemberController.java
@@ -104,6 +104,7 @@ public class MemberController {
     }
 
     // 이메일로 회원식별키 조회
+    @GetMapping("/members/id")
     public ResponseEntity<Long> getMemberIdByEmail(@RequestHeader("X-USER-ID") String email) {
         return ResponseEntity.ok(memberService.getMemberIdByEmail(email));
     }

--- a/src/main/java/com/nhnacademy/book/member/domain/service/Impl/MemberServiceImpl.java
+++ b/src/main/java/com/nhnacademy/book/member/domain/service/Impl/MemberServiceImpl.java
@@ -469,4 +469,14 @@ public class MemberServiceImpl implements MemberService {
 
     }
 
+    @Override
+    public Long getMemberIdByEmail(String email) {
+        Long memberId = memberRepository.getMemberIdByEmail(email);
+
+        if (memberId == null) {
+            throw new MemberEmailNotFoundException("이메일에 해당하는 회원이 없습니다.");
+        }
+
+        return memberId;
+    }
 }

--- a/src/main/java/com/nhnacademy/book/member/domain/service/MemberService.java
+++ b/src/main/java/com/nhnacademy/book/member/domain/service/MemberService.java
@@ -18,4 +18,5 @@ public interface MemberService {
     void updateActiveStatus(String email);
     void updateDormantStatus();
     void updateMemberByAdmin(String email, MemberModifyByAdminRequestDto memberModifyByAdminRequestDto);
+    Long getMemberIdByEmail(String email);
 }

--- a/src/test/java/com/nhnacademy/book/member/domain/controller/MemberControllerTest.java
+++ b/src/test/java/com/nhnacademy/book/member/domain/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.book.member.domain.controller;//package com.nhnacademy.book.member.domain.controller;
 
+import com.nhnacademy.book.member.domain.Member;
 import com.nhnacademy.book.member.domain.MemberGrade;
 import com.nhnacademy.book.member.domain.MemberStatus;
 import com.nhnacademy.book.member.domain.dto.*;
@@ -345,6 +346,23 @@ class MemberControllerTest {
 
         assertEquals(200, responseEntity.getStatusCodeValue());
         verify(memberService, times(1)).updateMemberByAdmin(eq(email), eq(memberModifyByAdminRequestDto));
+    }
+
+    @Test
+    @DisplayName("이메일로 회원식별키 조회")
+    void getMemberIdByEmail() {
+        String email = "test@naver.com";
+        Long memberId = 1L;
+
+        when(memberService.getMemberIdByEmail(email)).thenReturn(memberId);
+
+        ResponseEntity<Long> responseEntity = memberController.getMemberIdByEmail(email);
+
+        assertEquals(200, responseEntity.getStatusCodeValue());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(memberId, responseEntity.getBody());
+
+        verify(memberService, times(1)).getMemberIdByEmail(email);
     }
 }
 

--- a/src/test/java/com/nhnacademy/book/member/domain/service/Impl/MemberServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/book/member/domain/service/Impl/MemberServiceImplTest.java
@@ -1022,4 +1022,51 @@ class MemberServiceImplTest {
         // Mock 호출 검증
         verify(memberRepository).findByEmail("yoonwlgh12@naver.com");
     }
+
+    @Test
+    @DisplayName("이메일로 회원식별키를 가져오는지")
+    void getMemberIdByEmail() {
+        // 테스트 용 이메일
+        String email = "test@naver.com";
+
+        // 기존의 회원 데이터
+        Member existingMember = new Member();
+        existingMember.setMemberId(1L);
+        existingMember.setEmail(email);
+
+        // 기존 회원 조회 Mock 설정
+        when(memberRepository.getMemberIdByEmail(email)).thenReturn(existingMember.getMemberId());
+
+        // 메서드 호출
+        Long memberId = memberService.getMemberIdByEmail(email);
+
+        // 일치하는지 검증
+        assertEquals(1L, memberId);
+
+        // Mock 호출 검증
+        verify(memberRepository).getMemberIdByEmail(email);
+    }
+
+    @Test
+    @DisplayName("이메일로 회원식별키를 못찾는 경우")
+    void getMemberIdByEmail_MemberNotFoundException() {
+        // 테스트 용 이메일
+        String email = "test@naver.com";
+
+        // 기존의 회원 데이터
+        Member existingMember = new Member();
+        existingMember.setMemberId(1L);
+        existingMember.setEmail(email);
+
+        // 기존 회원 조회 Mock 설정
+        when(memberRepository.getMemberIdByEmail(email)).thenReturn(null);
+
+        // 이메일로 회원 식별키를 못찾을 경우 예외 발생 확인
+        assertThrows(MemberEmailNotFoundException.class, () ->
+                memberService.getMemberIdByEmail(email)
+        );
+
+        // Mock 호출 검증
+        verify(memberRepository).getMemberIdByEmail(email);
+    }
 }


### PR DESCRIPTION
프론트서버에서 회원식별키 없이 쿠폰데이터를 끌고오는 방법이 없어서 추가했습니다